### PR TITLE
Fix compressor bug when zarr data is uncompressed 

### DIFF
--- a/code/aind_large_scale_cellpose/cellpose_segmentation/utils/upscale_mask.py
+++ b/code/aind_large_scale_cellpose/cellpose_segmentation/utils/upscale_mask.py
@@ -279,10 +279,28 @@ def upscale_mask(
         " Image shape: ",
         image_shape,
     )
+    #image_compressor = image_metadata[".zarray"]["compressor"]
+    
+    # Add this check and conversion:
+    if isinstance(image_compressor, dict):
+        if image_compressor["id"] == "blosc":
+            image_compressor = numcodecs.Blosc(
+                cname=image_compressor.get("cname", "zstd"),
+                clevel=image_compressor.get("clevel", 1),
+                shuffle=image_compressor.get("shuffle", 1),
+                blocksize=image_compressor.get("blocksize", 0)
+            )
+        else:
+            # Default fallback if compressor type is unknown
+            image_compressor = numcodecs.Blosc(cname="zstd", clevel=3)
+    elif image_compressor is None:
+        image_compressor = numcodecs.Blosc(cname="zstd", clevel=3)
 
-    image_compressor = (
-        numcodecs.Blosc(cname="zstd", clevel=3) if image_compressor is None else image_compressor
-    )
+    #print("Image compressor: ", image_compressor)
+
+    #image_compressor = (
+    #    numcodecs.Blosc(cname="zstd", clevel=3) if image_compressor is None else image_compressor
+    #)
     print("Image compressor: ", image_compressor)
     # Reading segmentation mask
     seg_mask_reader = ImageReaderFactory().create(
@@ -307,7 +325,7 @@ def upscale_mask(
     upscale_zarr_with_padding(
         input_zarr=lazy_mask_data,
         output_params=output_params,
-        upscale_factors_zyx=(1, 4, 4),  # TODO Calculate factors based on metadata
+        upscale_factors_zyx=(4, 4, 4),  # TODO Calculate factors based on metadata
         new_shape=image_lazy_data.shape,
         n_workers=n_workers,
     )

--- a/code/aind_large_scale_cellpose/segment.py
+++ b/code/aind_large_scale_cellpose/segment.py
@@ -163,6 +163,7 @@ def segment(
 
         # Output mask
         output_segmentation_mask = scheduler_params["generate_masks"]["output_mask"]
+        #output_segmentation_mask_filename = Path(output_segmentation_mask)
         prediction_chunksize = scheduler_params["generate_masks"]["prediction_chunksize"]
         super_chunksize = scheduler_params["generate_masks"]["super_chunksize"]
 
@@ -195,7 +196,7 @@ def segment(
                 dataset_path=dataset_paths[0],
                 segmentation_mask_path=output_segmentation_mask,
                 output_folder=results_folder,
-                filename="segmentation_mask.zarr",
+                filename= f"segmentation_mask.zarr",
                 dest_multiscale="0",
                 n_workers=co_cpus,
             )

--- a/code/aind_large_scale_cellpose/segment.py
+++ b/code/aind_large_scale_cellpose/segment.py
@@ -163,7 +163,6 @@ def segment(
 
         # Output mask
         output_segmentation_mask = scheduler_params["generate_masks"]["output_mask"]
-        #output_segmentation_mask_filename = Path(output_segmentation_mask)
         prediction_chunksize = scheduler_params["generate_masks"]["prediction_chunksize"]
         super_chunksize = scheduler_params["generate_masks"]["super_chunksize"]
 

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -1,23 +1,21 @@
 """ top level run script """
 
 import os
+import pathlib
+import argparse 
 
 from aind_large_scale_cellpose.segment import segment
 
-
-def run():
-    """Runs large-scale cell segmentation"""
+def run(dataset):
+    """Runs large-scale cell segmentation
+    
+    Args:
+        dataset (str): Name of the dataset to process
+    """
     # Code ocean folders
     results_folder = os.path.abspath("../results")
     data_folder = os.path.abspath("../data")
     scratch_folder = os.path.abspath("../scratch")
-
-    # Dataset to process
-    IMAGE_PATH = "HCR_742354_2024-08-30_18-00-00"
-    # "HCR_736207.01_2024-07-25_13-00-00"
-    # "HCR_736207-05_2024-08-02_13-00-00"
-    BKG_CHN = "fused/channel_488.zarr"
-    # NUCLEI_CHN = "channel_3.zarr"
 
     # NOTE: Change the cell diameter based on multiscale
     multiscale = "2"
@@ -51,17 +49,17 @@ def run():
             "prediction_chunksize": (3, 128, 128, 128),
         },
         "generate_masks": {
-            "output_mask": f"{results_folder}/segmentation_mask_orig_res.zarr",
+            "output_mask": f"{results_folder}/{dataset}/segmentation_mask_orig_res.zarr",
             "prediction_chunksize": (3, 128, 128, 128),
             "super_chunksize": (3, 512, 512, 512),
         },
     }
 
-    # dataset_path = f"s3://{BUCKET_NAME}/{IMAGE_PATH}/{TILE_NAME}"
-    background_channel = f"{data_folder}/{IMAGE_PATH}/{BKG_CHN}"
-    # nuclei_channel = f"{data_folder}/{IMAGE_PATH}/{NUCLEI_CHN}"
+    BKG_CHN = 'SPIM.ome.zarr/Tile_X_0000_Y_0000_Z_0000_ch_405.zarr'
+    background_channel = f"{data_folder}/{dataset}/{BKG_CHN}"
+    dataset_paths = [background_channel]
 
-    dataset_paths = [background_channel]  # , nuclei_channel]
+    print(f'Segmenting {background_channel}')
 
     segment(
         dataset_paths=dataset_paths,
@@ -75,6 +73,8 @@ def run():
         upsample_masks_levels=1,
     )
 
-
 if __name__ == "__main__":
-    run()
+    parser = argparse.ArgumentParser(description="Run cell segmentation on a specified dataset")
+    parser.add_argument("dataset", type=str, help="Name of the dataset to process")
+    args = parser.parse_args()
+    run(args.dataset)

--- a/code/run_capsule.py
+++ b/code/run_capsule.py
@@ -49,17 +49,23 @@ def run(dataset):
             "prediction_chunksize": (3, 128, 128, 128),
         },
         "generate_masks": {
-            "output_mask": f"{results_folder}/{dataset}/segmentation_mask_orig_res.zarr",
+            "output_mask": f"{results_folder}/segmentation_mask_orig_res.zarr",
             "prediction_chunksize": (3, 128, 128, 128),
             "super_chunksize": (3, 512, 512, 512),
         },
     }
 
-    BKG_CHN = 'SPIM.ome.zarr/Tile_X_0000_Y_0000_Z_0000_ch_405.zarr'
-    background_channel = f"{data_folder}/{dataset}/{BKG_CHN}"
-    dataset_paths = [background_channel]
+    #BKG_CHN = 'fused/channel_405.zarr'
+    #NUCLEI_CHN = 'fused/channel_594.zarr'
 
-    print(f'Segmenting {background_channel}')
+    #single tile BKG_CHN
+    BKG_CHN = 'SPIM.ome.zarr/Tile_X_0000_Y_0000_Z_0000_ch_405.zarr'
+
+    background_channel = f"{data_folder}/{dataset}/{BKG_CHN}"
+    #nuclei_channel = f"{data_folder}/{dataset}/{NUCLEI_CHN}"
+    dataset_paths = [background_channel]#, nuclei_channel]
+
+    print(f'Segmenting {dataset_paths}')
 
     segment(
         dataset_paths=dataset_paths,

--- a/metadata/metadata.yml
+++ b/metadata/metadata.yml
@@ -1,5 +1,5 @@
 metadata_version: 1
-name: aind-large-scale-cellpose
+name: aind-large-scale-cellpose_single_tile_copy
 description: Large-scale cell segmentation for Z1 data.
 authors:
 - name: Camilo Laiton


### PR DESCRIPTION
Fix logic associated with compressor defaults. 
This code was modified to optimize single tile segmentation, including the upsampling amount per axis (Normal fused volumes should be (1,4,4), but this is unfused so (4,4,4)